### PR TITLE
Feature/update n samples approx usage

### DIFF
--- a/eesampling/CHANGELOG.md
+++ b/eesampling/CHANGELOG.md
@@ -4,11 +4,10 @@ Changelog
 Development
 -----------
 
-* Placeholder
+* Made adjustment to how n_samples_approx is calculated. It now works where the minimum sampled:treatment ratio can be violated if n_samples_approx is used as an upper bound and that upper bound is reached.
 
 0.7.0
 -----
-
 
 * Rename train --> tretment, test --> pool 
 
@@ -17,10 +16,8 @@ Development
 
 * Fix Github URL
 
-
 0.6.0
 -----
-
 
 * First public release 
 * Update default params for bin_selection.StratifiedSamplingBinSelector(...) so n_samples_approx = 5000 and relax_n_samples_approx_constraint=False and min_n_sampled_to_n_train_ratio = 0.25, which means that we aim for 5000 comparison group meters but if we can't reach it, we need at least 0.25 sample to train ratio or else it fails. 
@@ -117,4 +114,4 @@ Development
 0.0.1
 -----
 
-* Created by [cookiecutter-etl-beam](https://github.com/openeemeter/cookiecutter-etl-beam)
+* Initial creation of library.

--- a/eesampling/eesampling/bin_selection.py
+++ b/eesampling/eesampling/bin_selection.py
@@ -130,6 +130,7 @@ class StratifiedSamplingBinSelector(object):
                 min_n_treatment_per_bin=min_n_treatment_per_bin,
                 random_seed=random_seed,
             )
+
             self.model.sample(
                 self.df_pool,
                 n_samples_approx=n_samples_approx,
@@ -139,7 +140,10 @@ class StratifiedSamplingBinSelector(object):
             n_sampled_to_n_treatment_ratio = (
                 self.model.diagnostics().n_sampled_to_n_treatment_ratio()
             )
-            if n_sampled_to_n_treatment_ratio < min_n_sampled_to_n_treatment_ratio:
+            if (
+                not self.model.relax_ratio_constraint
+                and n_sampled_to_n_treatment_ratio < min_n_sampled_to_n_treatment_ratio
+            ):
                 logger.info(
                     f"Insufficient pool data for {bins_selected_str}:"
                     f"found {n_sampled_to_n_treatment_ratio}:1 but need "
@@ -306,7 +310,8 @@ class StratifiedSamplingBinSelector(object):
     def plot_records_based_equiv_average(self, plot=True):
 
         equiv_df = pd.concat(
-            [self.equiv_treatment_avg, self.equiv_pool_avg, self.equiv_samples_avg], axis=1
+            [self.equiv_treatment_avg, self.equiv_pool_avg, self.equiv_samples_avg],
+            axis=1,
         )
 
         wrong_models = [

--- a/eesampling/eesampling/bins.py
+++ b/eesampling/eesampling/bins.py
@@ -278,11 +278,16 @@ def get_counts_and_update_n_samples_approx(
         counts["n_samples_available"] < counts["n_target"]
     )
     relax_ratio_constraint = False
-    if relax_n_samples_approx_constraint and not has_enough_for_n_samples_approx:
-        # Scenario 2: n_samples_approx=value and that value can not be met
+    if has_enough_for_n_samples_approx:
+        # Scenario 2: n_samples_approx=value so we want to ignore the ratio constraint
+        relax_ratio_constraint = True
+    elif relax_n_samples_approx_constraint:
+        # Scenario 3: n_samples_approx=value and that value but that value can not
+        # be met, so we want as many as possible and it is valid as long as it
+        # meets the ratio constraint.
         n_samples_approx = max_possible_n_samples_approx
         counts["n_target"] = np.floor(counts["n_pct"] * n_samples_approx).astype(int)
-    elif has_enough_for_n_samples_approx:
-        # Scenario 3: n_samples_approx=value but we want to ignore the ratio
-        relax_ratio_constraint = True
+    # else:
+        # Scenario 4: It will fail during sampling because it can not meet 
+        # n_samples_approx and we did not relax that constraint.
     return n_samples_approx, relax_ratio_constraint, counts


### PR DESCRIPTION
This PR generalizes how the code that figures out how many samples to pull from the comparison pool for a given bin configuration. It allows for a variety of scenarios based on four parameters:

n_samples_approx
relax_n_samples_approx_constraint

min_n_sampled_to_n_treatment_ratio

The following are the two suggested scenarios for now:

1. The end result should sample as many meters from the comparison pool as it possibly can, but disqualify if min_n_sampled_to_n_treatment_ratio=4 can not be met for any bin.

Kwarg values:
- n_samples_approx=None
- relax_n_samples_approx_constraint=True/False
- min_n_sampled_to_n_treatment_ratio=4
 
2. The end result should sample as many meters from the comparison pool as it possibly can, with an upper limit of n_samples_approx=5000. If it is able to sample n_samples_approx, then it is valid regardless of the min_n_sampled_to_n_treatment_ratio. If there are too many bins that it can not reach n_samples_approx, then disqualify if it can't maintain the min_n_sampled_to_n_treatment_ratio, otherwise it is valid. This means that the final samples will maintain a minimum ratio of 4:1 and sample as many as they can, up until 5000 samples, in which case the ratio is disregarded.

Kwarg values:
- n_samples_approx=5000
- relax_n_samples_approx_constraint=True
- min_n_sampled_to_n_treatment_ratio=4

We will continue to iterate on how n_sample selection occurs and will make future PRs to further clarify and simplify this step