### PR TITLE
speed up equivalence; fix ID column

### DIFF
--- a/eesampling/eesampling/bin_selection.py
+++ b/eesampling/eesampling/bin_selection.py
@@ -38,6 +38,7 @@ class StratifiedSamplingBinSelector(object):
         equivalence_value_col,
         equivalence_id_col,
         how,
+        df_id_col="id",
         n_samples_approx=5000,
         min_n_treatment_per_bin=0,
         random_seed=1,
@@ -87,6 +88,7 @@ class StratifiedSamplingBinSelector(object):
         self.equivalence_groupby_col = equivalence_groupby_col
         self.equivalence_value_col = equivalence_value_col
         self.equivalence_id_col = equivalence_id_col
+        self.df_id_col = df_id_col
 
         self.model = model
         self.df_treatment = df_treatment
@@ -169,9 +171,10 @@ class StratifiedSamplingBinSelector(object):
                 continue
             equiv_treatment, equiv_sample, equivalence_distance = self.model.diagnostics().records_based_equivalence(
                 self.df_for_equivalence,
-                equivalence_groupby_col,
-                equivalence_value_col,
-                id_col=equivalence_id_col,
+                equiv_groupby_col=equivalence_groupby_col,
+                equiv_value_col=equivalence_value_col,
+                equiv_id_col=equivalence_id_col,
+                id_col=df_id_col,
                 how=how,
                 chisquare_n_values_per_bin=chisquare_n_values_per_bin,
                 chisquare_is_fixed_width=chisquare_is_fixed_width,
@@ -234,7 +237,7 @@ class StratifiedSamplingBinSelector(object):
         def _get_equiv_comparison_pool():
             df_combined = self.df_for_equivalence[
                 self.df_for_equivalence[self.equivalence_id_col].isin(
-                    self.df_pool[self.equivalence_id_col]
+                    self.df_pool[self.df_id_col]
                 )
             ]
             equiv_full_avg = df_combined.groupby(self.equivalence_groupby_col)[

--- a/eesampling/eesampling/bin_selection.py
+++ b/eesampling/eesampling/bin_selection.py
@@ -230,7 +230,7 @@ class StratifiedSamplingBinSelector(object):
         def _get_equiv_comparison_pool():
             df_combined = self.df_for_equivalence[
                 self.df_for_equivalence[self.equivalence_id_col].isin(
-                    self.df_pool["id"]
+                    self.df_pool[self.equivalence_id_col]
                 )
             ]
             equiv_full_avg = df_combined.groupby(self.equivalence_groupby_col)[

--- a/eesampling/eesampling/diagnostics.py
+++ b/eesampling/eesampling/diagnostics.py
@@ -276,9 +276,10 @@ class Diagnostics(DiagnosticPlotter):
     def records_based_equivalence(
         self,
         df_for_equivalence,
-        groupby_col,
-        value_col,
+        equiv_groupby_col,
+        equiv_value_col,
         how,
+        equiv_id_col="id",
         id_col="id",
         equiv_label_x=None,
         equiv_label_y=None,
@@ -288,8 +289,9 @@ class Diagnostics(DiagnosticPlotter):
         if how == "euclidean":
             return self.records_based_equivalence_euclidean(
                 df_for_equivalence=df_for_equivalence,
-                groupby_col=groupby_col,
-                value_col=value_col,
+                equiv_groupby_col=equiv_groupby_col,
+                equiv_value_col=equiv_value_col,
+                equiv_id_col=equiv_id_col,
                 id_col=id_col,
                 equiv_label_x=equiv_label_x,
                 equiv_label_y=equiv_label_y,
@@ -297,8 +299,9 @@ class Diagnostics(DiagnosticPlotter):
         elif how == "chisquare":
             return self.records_based_equivalence_chisquare(
                 df_for_equivalence=df_for_equivalence,
-                groupby_col=groupby_col,
-                value_col=value_col,
+                equiv_groupby_col=equiv_groupby_col,
+                equiv_value_col=equiv_value_col,
+                equiv_id_col=equiv_id_col,
                 id_col=id_col,
                 equiv_label_x=equiv_label_x,
                 equiv_label_y=equiv_label_y,
@@ -311,8 +314,9 @@ class Diagnostics(DiagnosticPlotter):
     def records_based_equivalence_euclidean(
         self,
         df_for_equivalence,
-        groupby_col,
-        value_col,
+        equiv_groupby_col,
+        equiv_value_col,
+        equiv_id_col="id",
         id_col="id",
         equiv_label_x=None,
         equiv_label_y=None,
@@ -332,16 +336,16 @@ class Diagnostics(DiagnosticPlotter):
 
         df = self.df_all[["population", id_col]].copy()
         df_combined = df.set_index(id_col, drop=True).join(
-            df_for_equivalence.set_index(id_col, drop=True)
+            df_for_equivalence.set_index(equiv_id_col, drop=True)
         )
         equiv_x = (
             df_combined[df_combined["population"] == equiv_label_x]
-            .groupby(groupby_col)[value_col]
+            .groupby(equiv_groupby_col)[equiv_value_col]
             .mean()
         )
         equiv_y = (
             df_combined[df_combined["population"] == equiv_label_y]
-            .groupby(groupby_col)[value_col]
+            .groupby(equiv_groupby_col)[equiv_value_col]
             .mean()
         )
         return equiv_x.to_frame(), equiv_y.to_frame(), pdist([equiv_x, equiv_y])[0]
@@ -350,8 +354,9 @@ class Diagnostics(DiagnosticPlotter):
     def records_based_equivalence_chisquare(
         self,
         df_for_equivalence,
-        groupby_col,
-        value_col,
+        equiv_groupby_col,
+        equiv_value_col,
+        equiv_id_col="id",
         id_col="id",
         equiv_label_x=None,
         equiv_label_y=None,
@@ -373,10 +378,10 @@ class Diagnostics(DiagnosticPlotter):
 
         df = self.df_all[["population", id_col]].copy()
         df_combined = df.set_index(id_col, drop=True).join(
-            df_for_equivalence.set_index(id_col, drop=True)
+            df_for_equivalence.set_index(equiv_id_col, drop=True)
         )
-        features = df_combined[groupby_col].unique()
-        df_combined = df_combined.set_index(['population', groupby_col]).sort_index()
+        features = df_combined[equiv_groupby_col].unique()
+        df_combined = df_combined.set_index(['population', equiv_groupby_col]).sort_index()
 
         chisquare_stats = []
         equiv_x = []
@@ -389,19 +394,19 @@ class Diagnostics(DiagnosticPlotter):
             num_bins = max(int(len(df_equiv_x) / chisquare_n_values_per_bin), 1)
 
             binned_data_x = df_equiv_x
-            binned_data_x['_bin_label'] = pd.qcut(binned_data_x[value_col], q=num_bins).astype(str)
+            binned_data_x['_bin_label'] = pd.qcut(binned_data_x[equiv_value_col], q=num_bins).astype(str)
 
             binned_data_y = df_equiv_y
-            binned_data_y['_bin_label'] = pd.qcut(binned_data_y[value_col], q=num_bins).astype(str)
+            binned_data_y['_bin_label'] = pd.qcut(binned_data_y[equiv_value_col], q=num_bins).astype(str)
 
-            chisquare_x = binned_data_x.groupby("_bin_label")[value_col].mean()
-            chisquare_y = binned_data_y.groupby("_bin_label")[value_col].mean()
+            chisquare_x = binned_data_x.groupby("_bin_label")[equiv_value_col].mean()
+            chisquare_y = binned_data_y.groupby("_bin_label")[equiv_value_col].mean()
             chisquare_stats.append(chisquare(chisquare_x, chisquare_y).statistic)
 
             chisquare_x_df = chisquare_x.to_frame()
-            chisquare_x_df[groupby_col] = groupby_col_num
+            chisquare_x_df[equiv_groupby_col] = groupby_col_num
             chisquare_y_df = chisquare_y.to_frame()
-            chisquare_y_df[groupby_col] = groupby_col_num
+            chisquare_y_df[equiv_groupby_col] = groupby_col_num
 
             equiv_x.append(chisquare_x_df)
             equiv_y.append(chisquare_y_df)

--- a/eesampling/tests/test_diagnostics.py
+++ b/eesampling/tests/test_diagnostics.py
@@ -45,7 +45,7 @@ def test_record_based_equivalence_euclidean(diagnostics_obj, df_treatment, df_po
 
     
     equivalence = diagnostics_obj.records_based_equivalence_euclidean(
-        df_equiv, groupby_col="month", value_col="baseline_predicted_usage"
+        df_equiv, equiv_groupby_col="month", equiv_value_col="baseline_predicted_usage"
     )
     assert equivalence
 
@@ -54,6 +54,6 @@ def test_record_based_equivalence_chisquare(diagnostics_obj, df_treatment, df_po
 
     
     equivalence = diagnostics_obj.records_based_equivalence_chisquare(
-        df_equiv, groupby_col="month", value_col="baseline_predicted_usage"
+        df_equiv, equiv_groupby_col="month", equiv_value_col="baseline_predicted_usage"
     )
     assert equivalence


### PR DESCRIPTION
Noticed "id" was hard-coded so I changed that (by making it its own variable for the core df)

I did two things that sped up the equivalence test:

- Indexed the data frame, so that subsetting was faster
- Replaced Binning with qcut

I think the latter is OK, because all you have to do is compute bins, you don't need to do anything else fancy, so you don't need all of the stuff in the Binning class.  Turns out Binning is pretty slow.  I think the algorithm has not changed.

I tested this with some synthetic data and for 10K meters with seasonal 168 equivalence data the bin selection runs in 45 seconds.